### PR TITLE
Workaround for podman-compose 1.3.0

### DIFF
--- a/ipalab-config/ipa-migration/README.md
+++ b/ipalab-config/ipa-migration/README.md
@@ -16,21 +16,21 @@ Build the containers:
 
 ```
 ipalab-config -f containerfile-fedora -p playbooks ipalab-migration.yaml
-podman-compose -f ipalab-migration/compose.yml up -d --build
-ansible-galaxy collection install -r ipalab-migration/requirements.yml
+cd ipalab-migration
+podman-compose up -d --build
+ansible-galaxy collection install -r requirements.yml
 ```
 
 Deploy the IPA cluster:
 
 ```
-ansible-playbook -i ipalab-migration/inventory.yml ipalab-migration/playbooks/install-cluster.yml
+ansible-playbook -i inventory.yml playbooks/install-cluster.yml
 ```
 
 To test ipa-migration, first create some objects in the origin server:
 
 ```
-ansible-playbook -i ipalab-migration/inventory.yml ipalab-migration/playbooks/users_present.yml
-
+ansible-playbook -i inventory.yml playbooks/users_present.yml
 ```
 
 Access the target server container:

--- a/ipalab-config/ipa-migration/playbooks/generate_test_data.yml
+++ b/ipalab-config/ipa-migration/playbooks/generate_test_data.yml
@@ -13,9 +13,10 @@
         echo "  {"
         echo "    \"name\": \"testuser_${i}\","
         echo "    \"first\": \"First ${i}\","
-        echo "    \"last\": \"Last ${i}\","
-        echo "    \"password\": \"user${i}PW\","
-        echo "    \"passwordexpiration\": \"${date}\""
+        echo "    \"last\": \"Last ${i}\""
+        # echo "    \"last\": \"Last ${i}\","
+        # echo "    \"password\": \"user${i}PW\","
+        # echo "    \"passwordexpiration\": \"${date}\""
         if [ "$i" -lt "{{ user_count }}" ]; then
            echo "  },"
         else


### PR DESCRIPTION
There's a regression issue in latest podman-compose releases where '-f' does not work when the file is not in the currrent directory.