### PR TITLE
Modified lab description and requirements

### DIFF
--- a/ipalab-config/ipa-tuura/README.md
+++ b/ipalab-config/ipa-tuura/README.md
@@ -1,0 +1,187 @@
+# FreeIPA integration with Keycloak using ipa-tuura bridge
+
+This lab sets up an environment that integrates [FreeIPA](https://freeipa.org) and [Keycloak](https://keycloak.org) identity management deployments using the **ipa-tuura** bridge via Keycloak's User Federation feature.
+
+**ipa-tuura** is a service that exposes identity and authentication domains through a set of Django applications, enabling centralized management of users, groups, and authentication methods.
+
+
+## Preparing the environment
+
+Create the configuration:
+
+```
+python3 -m venv /tmp/ipalab
+. /tmp/ipalab/bin/activate
+pip install -r requirements.txt
+```
+
+Build the container image and instantiate containers:
+
+```
+ipalab-config lab_ipa_tuura.yml
+cd ipa-tuura-keycloak
+podman-compose build
+podman-compose up -d
+```
+
+At this stage, the environment consists of three containers:  
+- A container based on the official Keycloak image  
+- A container ready for deploying FreeIPA  
+- The **ipa-tuura** service container, which bridges FreeIPA and Keycloak by integrating them through Keycloak's User Federation storage
+
+Deploy the IPA cluster using
+[ansible-freeipa](https://gtihub.com/freeipa/ansible-freeipa):
+
+```
+ansible-galaxy collection install \
+    freeipa.ansible_freeipa \
+    containers.podman
+ansible-playbook -i inventory.yml \
+    ${HOME}/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml
+```
+
+The provided Keycloak container uses a self-signed certificate that is
+unkown to the ipa-tuura container. The certificate is found in the container
+`keycloak` at the path `/opt/keycloak/conf/cert.pem`. This certificate
+must be added to the list of trusted certificates on the ipa-tuura
+container. This can be achieved by executing:
+
+```
+keycloak/trust_keycloak.sh ipatuura
+```
+
+## Using Keycloak web interface
+
+Since the whole environment runs using rootles containers, in a Podman
+virtual network, direct access to the host ports is not possible, but
+can be achieved using `podman unshare`. For example, to _ssh_ into the
+container (if `sshd` is available) or to access the `httpd` server.
+
+When using [Firefox](https://mozilla.org/firefox) a profile is needed
+to access the containers URLs, and to ease access the script
+`scripts/open-firefox.sh` is provided. This script will manage the
+Firefox profile and call `firefox` with the proper configuration for
+`podman unshare`, allowing access to Keycloak and WebUI.
+
+Before starting Firefox, add the entries found in the generated `hosts`
+file to your machine `/etc/hosts` so the host names can be resolved. The
+file `hosts` has all the containers entries needed, add it with:
+
+```
+sudo bash -c "cat hosts >> /etc/hosts"
+```
+
+Start the Keycloak web interface with:
+
+```
+scripts/open-firefox.sh https://keycloak.example.test:8443
+```
+
+Start the IPA WebUI with:
+
+```
+scripts/open-firefox.sh https://server.ipa.test:443
+```
+
+In a similar fashion you can access the Bridge API with:
+
+```
+scripts/open-firefox.sh https://ipatuura.ipa.test:443
+```
+
+
+## Setting up Keycloak's User Federation Storage
+
+
+In order to interconnect both identity management systems, the **ipa-tuura** service must be added as part of Keycloak's *User Federation* storage.
+
+```json
+                  ./kcadm.sh create components \
+                    -r master \
+                    -s name=scimipa \
+                    -s providerId=scim \
+                    -s providerType=org.keycloak.storage.UserStorageProvider \
+                    -s 'config.scimurl=["bridge.ipa.test"]' \
+                    -s 'config.loginusername=["scim"]' \
+                    -s 'config.loginpassword=["Secret123"]' \
+                    -s 'config.domain=["ipa.test"]' \
+                    -s 'config.domainname=["ipa.test"]' \
+                    -s 'config.domaindesc=["Bridge_to_ipa"]' \
+                    -s 'config.domainurl=["https://idm.ipa.test"]' \
+                    -s 'config.domainclientid=["admin"]' \
+                    -s 'config.domainclientsecret=["Secret123"]' \
+                    -s 'config.idprovider=["ipa"]' \
+                    -s 'config.cacert=["/etc/ipa/ca.crt"]' \
+                    -s 'config.users_dn=["ou=people,dc=ipa,dc=test"]' \
+                    -s 'config.extraattrs=["mail:mail, sn:sn, givenname:givenname"]' \
+                    -s 'config.addintgdomain=["True"]' \
+                    -s 'config.enabled=["True"]' \
+                    -s 'config.keycloak_hostname=["keycloak.ipa.test"]'
+```
+
+CHECK IF WE CAN CREATE A JSON and rely on kcreg:
+
+```json
+{
+  "enabled" : true,
+  "clientAuthenticatorType" : "client-secret",
+  "redirectUris" : [ "https://${IPASERVER}/ipa/idp/*" ],
+  "webOrigins" : [ "https://${IPASERVER}" ],
+  "protocol" : "openid-connect",
+  "attributes" : {
+    "oauth2.device.authorization.grant.enabled" : "true",
+    "oauth2.device.polling.interval": "5"
+  }
+}
+```
+
+
+To create the OIDC client for Keycloak, you can use the script provided
+by `ipalab-config`. The script requires the IPA FQDN, an OIDC client ID
+and the OIDC client password. Execute:
+
+```
+keycloak/keycloak_add_oidc_client.sh \
+    server.ipa.test \
+    ipa_oidc_client \
+    Secret123
+```
+
+Now, we can start adding some users to IPA deploytment, and check if they are automatically provisioned in Keycloak by running:
+
+```
+ansible-playbook -i inventory.yml playbooks/add_ipa_users.yml
+```
+
+## Testing the setup
+
+To test the setup, create a user on IPA using:
+
+```
+ansible-playbook -i inventory.yml playbooks/add_user_auth_idp.yml
+```
+
+Perform login with user `jdoe` on Keycloak web interface:
+
+```
+scripts/open-firefox.sh https://keycloak.example.test:8443/realms/master/account
+```
+
+
+## Troubleshooting
+
+ADD ipa-tuura troubleshooting
+
+If anything goes wrong, you can search `journalctl` for `ipa-otpd`
+entries.
+
+To increase the log level, set the `oidc_child` debug level in
+`/etc/ipa/default.conf` by setting:
+
+```
+[global]
+oidc_child_debug_level=10
+```
+
+Valid values are between 0 and 10 and any value above 6 includes debug
+output from `libcurl` utility.

--- a/ipalab-config/ipa-tuura/ipa-keycloak-idp.tape
+++ b/ipalab-config/ipa-tuura/ipa-keycloak-idp.tape
@@ -1,0 +1,152 @@
+Output out.webm
+Set FontSize 16
+Set Width 1200
+Set Height 800
+Require python3
+Require podman
+Sleep 2s
+Hide
+Type "export PS1='[\W]$ '"
+Enter
+Wait /.*[\$#] *$/
+Type "command -v deactivate && deactivate"
+Enter
+Wait /.*[\$#] *$/
+Type "rm -rf /tmp/ipalab-ipa-keycloak"
+Enter
+Wait /.*[\$#] *$/
+Ctrl+L
+Show
+Type "`# Install support software`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "python3 -m venv /tmp/ipalab-ipa-keycloak"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type ". /tmp/ipalab-ipa-keycloak/bin/activate"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "pip install -r requirements.txt"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Sleep 3s
+Ctrl+L
+Type "`# Create and activate the configuration`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "ipalab-config lab_ipa_keycloak.yml"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "cd ipa-keycloak-idp"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "podman-compose build"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "podman-compose up -d"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "`# Trust Keycloak self-signed certificate`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "keycloak/trust_keycloak.sh server"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Sleep 3s
+Ctrl+L
+Type "`# Install containers.podman collection`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "ansible-galaxy collection install containers.podman"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "`# Install freeipa.ansible_freeipa collection`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "ansible-galaxy collection install freeipa.ansible_freeipa"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Sleep 3s
+Ctrl+L
+Type "`# Video cut to deploy IPA cluster`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "`# ansible-playbook -i inventory.yml ${ansible_freeipa_collection_path}install-cluster.yml`"
+Sleep 500ms
+Enter
+Sleep 5s
+Hide
+Type "ansible-playbook -i inventory.yml ~/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml"
+Enter
+Wait@10m  /.*[\$#] *$/
+Show
+Type "`# Create Keycloak OIDC client`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "keycloak/keycloak_add_oidc_client.sh  server.ipa.test ipa_oidc_client Secret123"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "`# Configure IDP endpoint in IPA`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "ansible-playbook -i inventory.yml playbooks/idp_keycloak.yml"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "`# Test IDP connection with user 'jdoe'`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "`# Create user on Keycloak`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "keycloak/keycloak_add_user.sh jdoe jdoe@example.test userPASS"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "`# Add user to IPA`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "ansible-playbook -i inventory.yml playbooks/add_user_auth_idp.yml"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Sleep 5s
+Ctrl+L
+Type "`# kinit user jdoe on IPA server`"
+Sleep 500ms
+Enter
+Sleep 5s
+Type "podman exec server kinit -n -c /fast.ccache"
+Sleep 500ms
+Enter
+Wait /.*[\$#] *$/
+Type "podman exec server kinit -T /fast.ccache jdoe"
+Sleep 500ms
+Enter
+Wait@5s  /.*[\$#] *$/
+Type "`# Some issues may be present in this demo, and for a complete execution, access to a browser is needed.`"
+Sleep 500ms
+Enter
+Sleep 5s

--- a/ipalab-config/ipa-tuura/lab_ipa_tuura.yml
+++ b/ipalab-config/ipa-tuura/lab_ipa_tuura.yml
@@ -1,0 +1,26 @@
+---
+lab_name: ipa-tuura-keycloak
+subnet: "192.168.173.0/24"
+# container_fqdn: true
+containerfiles:
+  - "ipa-tuura.containerfile"
+external:
+  hosts:
+  - name: keycloak
+    hostname: keycloak.external.test
+    role: keycloak
+    options:
+      # admin_username: defaults to "admin"
+      # admin_password: defaults to "secret123"
+  - name: ipatuura
+    hostname: ipatuura.ipa.test
+    distro: "ipa-tuura.containerfile"
+ipa_deployments:
+  - name: ipa
+    domain: ipa.test
+    admin_password: SomeADMINpassword
+    dm_password: SomeDMpassword
+    cluster:
+      servers:
+        - name: server
+          # capabilities: ["DNS"]

--- a/ipalab-config/ipa-tuura/lab_ipa_tuura.yml
+++ b/ipalab-config/ipa-tuura/lab_ipa_tuura.yml
@@ -2,8 +2,6 @@
 lab_name: ipa-tuura-keycloak
 subnet: "192.168.173.0/24"
 # container_fqdn: true
-containerfiles:
-  - "ipa-tuura.containerfile"
 external:
   hosts:
   - name: keycloak
@@ -14,7 +12,7 @@ external:
       # admin_password: defaults to "secret123"
   - name: ipatuura
     hostname: ipatuura.ipa.test
-    distro: "ipa-tuura.containerfile"
+    image: "quay.io/freeipa/ipa-tuura:latest"
 ipa_deployments:
   - name: ipa
     domain: ipa.test

--- a/ipalab-config/ipa-tuura/playbooks/add_ipa_users.yml
+++ b/ipalab-config/ipa-tuura/playbooks/add_ipa_users.yml
@@ -1,0 +1,22 @@
+---
+- name: Add Keycloak as an external IDP for IPA
+  hosts: ipaserver
+  become: false
+  gather_facts: false
+
+  collections:
+    - freeipa.ansible_freeipa
+
+  module_defaults:
+    group/freeipa.ansible_freeipa.modules:
+      ipaadmin_password: SomeADMINpassword
+
+  tasks:
+  - name: Ensure Keycloak IDP is present
+    ipaidp:
+      name: keycloak-idp
+      provider: keycloak
+      organization: master
+      base_url: "https://keycloak.example.test:8443"
+      client_id: ipa_oidc_client
+      secret: Secret123

--- a/ipalab-config/ipa-tuura/playbooks/add_user_auth_idp.yml
+++ b/ipalab-config/ipa-tuura/playbooks/add_user_auth_idp.yml
@@ -1,0 +1,23 @@
+---
+- name: Add IPA user using IDP authorization
+  hosts: ipaserver
+  become: false
+  gather_facts: false
+
+  collections:
+    - freeipa.ansible_freeipa
+
+  module_defaults:
+    group/freeipa.ansible_freeipa.modules:
+      ipaadmin_password: SomeADMINpassword
+
+  tasks:
+  - name: Ensure user 'jdoe' exists and uses 'idp' for authorization
+    ipauser:
+      name: jdoe
+      first: John
+      last: doe
+      email: jdoe@ipa.test
+      idp: keycloak-idp
+      idp_user_id: jdoe@example.test
+      userauthtype: idp

--- a/ipalab-config/ipa-tuura/requirements.txt
+++ b/ipalab-config/ipa-tuura/requirements.txt
@@ -1,2 +1,2 @@
-ipalab-config>=0.13
+ipalab-config>=0.14
 ansible-core

--- a/ipalab-config/ipa-tuura/requirements.txt
+++ b/ipalab-config/ipa-tuura/requirements.txt
@@ -1,0 +1,2 @@
+ipalab-config>=0.13
+ansible-core

--- a/ipalab-config/ipa-tuura/scripts/open-firefox.sh
+++ b/ipalab-config/ipa-tuura/scripts/open-firefox.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+die() {
+    >&2 echo $*
+    exit 1
+}
+
+detach() {
+    nohup "$@" >/dev/null 2>&1 </dev/null &
+}
+
+usage() {
+    cat <<EOF
+usage: $(basename "$0") [-p PROFILE] [-r] [URL]"
+
+Open URL in Firefox with the given profile.
+
+Options:
+
+    -p PROFILE   use the given profile name
+    -r           remove the profile
+
+EOF
+}
+
+
+MOZILLA_PROFILES="${HOME}/.mozilla/firefox/profiles.ini"
+
+profile_name="ipalab-profile"
+cmd="open"
+
+while getopts ":hp:r" option
+do
+    case "${option}" in
+        h) usage && exit 0 ;;
+        p) profile_name="${OPTARG}" ;;
+        r) cmd="remove" ;;
+        *) die -u "Invalid option: ${OPTARG}" ;;
+    esac
+done
+shift "$((OPTIND - 1))"
+
+[ $# -gt 1 ] && die "Only one URL can be used. (Didn't you forgot '-p'?)"
+
+echo "Using profile ${profile_name}"
+
+WORKSHOP_PROFILE_DIR="${HOME}/.mozilla/firefox/${profile_name}"
+
+if [ "$cmd" == "remove" ]
+then
+    sed -i "/^\# start - Added by ipalab-config: ${profile_name}$/,/^\# end - Added by ipalab-config: ${profile_name}/d" "${MOZILLA_PROFILES}"
+    rm -rf "${WORKSHOP_PROFILE_DIR}"
+    exit
+fi
+
+if [ ! -d "${WORKSHOP_PROFILE_DIR}" ]
+then
+    mkdir "${WORKSHOP_PROFILE_DIR}"
+    certutil -N -d "${WORKSHOP_PROFILE_DIR}"
+    podman cp server:/etc/ipa/ca.crt "${WORKSHOP_PROFILE_DIR}/ca.crt"
+    certutil -A -i "${WORKSHOP_PROFILE_DIR}/ca.crt" -d "${WORKSHOP_PROFILE_DIR}" -n "Certificate Authority - IPA dev ${profile_name}" -t "CT,C,"
+fi
+
+if ! grep -q "Name=${profile_name}" "${MOZILLA_PROFILES}"
+then
+    echo "Creating Firefox profile: ${profile_name}"
+
+    next_profile=$(echo $(($(cat "${MOZILLA_PROFILES}" | sed -n 's/\[Profile\([^\]]*\)\]/\1/p' | sort -n | tail -n 1) + 1)))
+
+    cat >> "${MOZILLA_PROFILES}" <<EOF
+# start - Added by ipa-demos: ${profile_name}
+[Profile${next_profile}]
+Name=${profile_name}
+IsRelative=1
+Path=${profile_name}
+# end - Added by ipa-demos
+EOF
+
+fi
+
+[ -z "$@" ] || detach podman unshare --rootless-netns firefox -P "$profile_name" --new-window "$@"

--- a/ipalab-config/ipa-tuura/vcr_demo.sh
+++ b/ipalab-config/ipa-tuura/vcr_demo.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -eu
+
+# vcr: -- This script is used to creath the vhs tape using vcr
+# vcr: -- vcr: https://github.com/rjeffman/vcr
+
+# vcr: hide
+export PS1='[\\W]$ '
+command -v deactivate && deactivate
+rm -rf /tmp/ipa-tuura-keycloak
+
+# vcr: clear show
+# Install support software
+python3 -m venv /tmp/ipa-tuura-keycloak
+. /tmp/ipa-tuura-keycloak/bin/activate
+pip install -r requirements.txt
+
+# vcr: clear
+# Create and activate the configuration
+ipalab-config lab_ipa_tuura.yml
+cd ipa-tuura-keycloak
+podman-compose build
+podman-compose up -d
+
+# Trust Keycloak self-signed certificate
+keycloak/trust_keycloak.sh ipatuura
+
+# vcr: clear
+# Install containers.podman collection
+ansible-galaxy collection install containers.podman
+# Install freeipa.ansible_freeipa collection
+ansible-galaxy collection install freeipa.ansible_freeipa
+
+# vcr: clear
+# Video cut to deploy IPA cluster
+# ansible-playbook -i inventory.yml ${ansible_freeipa_collection_path}\install-cluster.yml
+# vcr: -- Hide IPA installation for smaller video.
+# vcr: hide timeout=10m
+ansible-playbook -i inventory.yml ~/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml
+
+# vcr: show
+# Create Keycloak OIDC client
+keycloak/keycloak_add_oidc_client.sh  server.ipa.test ipa_oidc_client Secret123
+
+# Configure IDP endpoint in IPA
+# ansible-playbook -i inventory.yml playbooks/idp_keycloak.yml
+
+# Test Automatic provisioning with user 'jdoe'
+
+# Add user to IPA
+ansible-playbook -i inventory.yml playbooks/add_user_auth_idp.yml
+
+# Authenticate in Keycloak
+#keycloak/keycloak_add_user.sh jdoe jdoe@example.test userPASS
+
+# kinit user jdoe on IPA server
+#podman exec server kinit -n -c /fast.ccache
+# vcr: timeout=5s
+#podman exec server kinit -T /fast.ccache jdoe
+
+# Some issues may be present in this demo, and for a complete execution, access to a browser is needed.
+


### PR DESCRIPTION
Modified the ipalab description to use ipatuura upstream image and requirements.txt to use ipalab-config version that supports the 'image' attribute.

## Summary by Sourcery

Update the ipa-tuura lab configuration to use the upstream container image via the `image` attribute and bump the ipalab-config dependency to version 0.14.

Enhancements:
- Use `image` attribute with upstream IPA Tuura image in the lab configuration
- Bump `ipalab-config` requirement to >=0.14 to support the new `image` attribute